### PR TITLE
fix: allow docker to assign port maps

### DIFF
--- a/pkg/localstack/start.go
+++ b/pkg/localstack/start.go
@@ -20,9 +20,6 @@ const (
 	defaultImage = "localstack/localstack"
 	// the single service port that LocalStack exposes by default
 	entryPort = "4566/tcp"
-	// range of additional service ports
-	portRangeStart = 4510
-	portRangeEnd   = 4559
 	// how long we’ll wait for pull+create operations
 	operationTimeout = 2 * time.Minute
 )
@@ -49,18 +46,14 @@ func NewRunner(cli *client.Client) (*Runner, error) {
 		Cli:          cli,
 		ImageURL:     defaultImageURL,
 		Image:        defaultImage,
-		PortBindings: buildPortMap(),
+		PortBindings: buildPortBindings(),
 	}, nil
 }
 
-// buildPortMap generates the same 4566 + 4510-4559 => 127.0.0.1 bindings.
-func buildPortMap() nat.PortMap {
+// buildPortBindings automatically generates the port bindings for LocalStack.
+func buildPortBindings() nat.PortMap {
 	pm := nat.PortMap{
-		nat.Port(entryPort): {{HostIP: "127.0.0.1", HostPort: "4566"}},
-	}
-	for p := portRangeStart; p <= portRangeEnd; p++ {
-		port := nat.Port(fmt.Sprintf("%d/tcp", p))
-		pm[port] = []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: fmt.Sprint(p)}}
+		"4566/tcp": {{HostIP: "127.0.0.1", HostPort: ""}}, // let Docker assign
 	}
 	return pm
 }


### PR DESCRIPTION
## Why and What

This pull request simplifies the way LocalStack service ports are configured in the `pkg/localstack/start.go` file. Instead of binding a large range of ports, it now only binds the main entry port and lets Docker assign the host port automatically.

**Port binding simplification:**

* Removed the explicit binding of the port range 4510–4559, so only the main LocalStack port (`4566/tcp`) is now bound, and Docker will assign the host port automatically. [[1]](diffhunk://#diff-4221ebdfde2b55deceb5a84ade369ae7611604e48a2fb0891754635a5b46fe24L23-L25) [[2]](diffhunk://#diff-4221ebdfde2b55deceb5a84ade369ae7611604e48a2fb0891754635a5b46fe24L52-R56)
* Renamed the helper function from `buildPortMap` to `buildPortBindings` to better reflect its purpose and updated its logic accordingly.